### PR TITLE
Add DWM1001 OTP antenna delay calibration values to docs

### DIFF
--- a/docs/boards/decawave-dwm1001.md
+++ b/docs/boards/decawave-dwm1001.md
@@ -5,10 +5,7 @@ group: boards
 ---
 
 
-The `dwm1001` board corresponds to the
-[Decawave DWM1001-DEV](https://www.decawave.com/product/dwm1001-development-board/) board. It
-runs on an nRF52832 ARM CortexM4 microcontroller from Nordic with BLE and UWB (Ultra-Wide Band) radio
-support.
+The `dwm1001` board corresponds to the Decawave DWM1001C from a [MDEK1001 Kit](https://www.qorvo.com/products/p/MDEK1001). It is a factory-calibrated version of the [Decawave DWM1001](https://www.decawave.com/product/dwm1001-development-board/) board and runs on an nRF52832 ARM CortexM4 microcontroller from Nordic with BLE and UWB (Ultra-Wide Band) radio support.
 
 <div style="text-align:center">
 <img src="{{ '/assets/images/docs/boards/dwm1001/' | relative_url}}dwm1001.jpeg" style="width:30%;"/>
@@ -33,7 +30,7 @@ microcontroller.
 
 ## Calibration of Antenna Delays
 
-The boards are precalibrated. The antenna delays (stored in OTP memory) for TX and RX (symmetric) are as follows:
+The boards are factory-calibrated by Decawave/Qorvo. The antenna delays (stored in OTP memory) for TX and RX (symmetric) are as follows:
 
 | Node                          	| Device UID 	| Delay Hex  	| Delay Decimal 	|
 |-------------------------------	|------------	|------	|---------	|

--- a/docs/boards/decawave-dwm1001.md
+++ b/docs/boards/decawave-dwm1001.md
@@ -29,3 +29,26 @@ The hardware configuration is available [<i class="far fa-file-pdf"/>&nbsp;here]
 
 The board is running on an [<i class="far fa-file-pdf"/>&nbsp;nrf52832](https://infocenter.nordicsemi.com/pdf/nRF52832_PS_v1.4.pdf)
 microcontroller.
+
+
+## Calibration of Antenna Delays
+
+The boards are precalibrated. The antenna delays for TX and RX (symmetric) are as follows:
+
+| Node                          	| Device UID 	| Hex  	| Decimal 	|
+|-------------------------------	|------------	|------	|---------	|
+| dwm1001-1.lille.iot-lab.info  	| 122E       	| 404A 	| 16458   	|
+| dwm1001-2.lille.iot-lab.info  	| 0420       	| 404B 	| 16459   	|
+| dwm1001-3.lille.iot-lab.info  	| 0C28       	| 4049 	| 16457   	|
+| dwm1001-4.lille.iot-lab.info  	| 0BA1       	| 4058 	| 16472   	|
+| dwm1001-5.lille.iot-lab.info  	| DB27       	| 404D 	| 16461   	|
+| dwm1001-6.lille.iot-lab.info  	| 0295       	| 404E 	| 16462   	|
+| dwm1001-7.lille.iot-lab.info  	| 8E2B       	| 4049 	| 16457   	|
+| dwm1001-8.lille.iot-lab.info  	| 8089       	| 4058 	| 16472   	|
+| dwm1001-9.lille.iot-lab.info  	| 08A6       	| 4058 	| 16472   	|
+| dwm1001-10.lille.iot-lab.info 	| D6B0       	| 4058 	| 16472   	|
+| dwm1001-11.lille.iot-lab.info 	| D1B6       	| 4034 	| 16436   	|
+| dwm1001-12.lille.iot-lab.info 	| DC19       	| 4039 	| 16441   	|
+| dwm1001-13.lille.iot-lab.info 	| 4827       	| 404B 	| 16459   	|
+| dwm1001-14.lille.iot-lab.info 	| D4B6       	| 4035 	| 16437   	|
+ 

--- a/docs/boards/decawave-dwm1001.md
+++ b/docs/boards/decawave-dwm1001.md
@@ -33,9 +33,9 @@ microcontroller.
 
 ## Calibration of Antenna Delays
 
-The boards are precalibrated. The antenna delays for TX and RX (symmetric) are as follows:
+The boards are precalibrated. The antenna delays (stored in OTP memory) for TX and RX (symmetric) are as follows:
 
-| Node                          	| Device UID 	| Hex  	| Decimal 	|
+| Node                          	| Device UID 	| Delay Hex  	| Delay Decimal 	|
 |-------------------------------	|------------	|------	|---------	|
 | dwm1001-1.lille.iot-lab.info  	| 122E       	| 404A 	| 16458   	|
 | dwm1001-2.lille.iot-lab.info  	| 0420       	| 404B 	| 16459   	|


### PR DESCRIPTION
I wanted the precalibrated antenna delays and read them from the OTP memory of the dwm1001 devices and put them into this table for the docs. However, while the results indicate some form of calibration, some more background info would be nice, i.e., are the devices factory-calibrated (holds for DWM1001C chips) or manually calibrated?

Best Regards,
Patrick