### PR TITLE
fix(iotnode): incorrect USART peripheral port

### DIFF
--- a/docs/boards/st-b-l475e-iot01a.md
+++ b/docs/boards/st-b-l475e-iot01a.md
@@ -18,7 +18,7 @@ also allows a UART connection to the M4.
 ## IoT-LAB special configuration
 
 The serial connection baudrate should be configured at **115200 bauds** in the
-firmware and use `USART2` on pins `PB7` (RX) and `PB6` (TX).
+firmware and use `USART1` on pins `PB7` (RX) and `PB6` (TX).
 
 ## Schematics and Datasheets
 


### PR DESCRIPTION
According to the datasheet table 17 (page 69), the USART that can be used with port PA9 for TX and PA10 for RX is USART1, not USART2. I tried using USART1 with PA9 and PA10 and I get an output on the serial monitor on the web interface.